### PR TITLE
Allow mounting /var/lib/nginx

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -30,6 +30,7 @@ ADD <%= ENV.fetch 'TAG' %>/test /tmp/test
 # docker-registry-proxy.crt and docker-registry-proxy.key to this volume, e.g.,
 # "-v /path/to/my/keys:/etc/nginx/ssl"
 VOLUME /etc/nginx/ssl
+VOLUME /var/lib/nginx
 EXPOSE 443
 
 CMD ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/bin/docker-registry-proxy
+++ b/bin/docker-registry-proxy
@@ -56,6 +56,7 @@ erb -T 2 "/etc/nginx/sites-available/proxy.conf.erb" > "/etc/nginx/sites-enabled
   (echo "Error creating nginx configuration." && exit 1)
 
 # Ensure that the nginx user can write to temp paths like client_body_temp_path.
+mkdir -p /var/lib/nginx
 chown -R www-data:www-data /var/lib/nginx
 
 # Ensure that the nginx user can write to its pid file.


### PR DESCRIPTION
It looks like our registry push woes might be caused by an awkward AUFS
(or Linux) bug.

Indeed, while it's hard to confirm, the following shell session suggests
that something is going wrong (note how the command fails at the
beginning, and eventually succeeds):

```
bash-4.3# sudo -u nginx -g nginx ls /var/lib/nginx/tmp/client_body/
ls: /var/lib/nginx/tmp/client_body/: Permission denied
bash-4.3# ls /var/lib/nginx/tmp
client_body  fastcgi      proxy        scgi         uwsgi
bash-4.3# ls -lah /var/lib/nginx/tmp
total 0
drwx------    8 nginx    nginx         24 Jun  9 14:57 .
drwx------    6 nginx    nginx         16 Jun  9 14:57 ..
drwx------    2 nginx    root           6 Jun  9 14:57 client_body
drwx------    2 nginx    root           6 Jan 25 19:34 fastcgi
drwx------    2 nginx    root           6 Jan 25 19:34 proxy
drwx------    2 nginx    root           6 Jan 25 19:34 scgi
drwx------    2 nginx    root           6 Jan 25 19:34 uwsgi
bash-4.3# ps -o pid,user,group,comm
PID   USER     GROUP    COMMAND
    1 root     root     run-docker-regi
   24 root     root     nginx
   25 nginx    nginx    nginx
   27 nginx    nginx    nginx
   28 nginx    nginx    nginx
   29 nginx    nginx    nginx
   30 root     root     tail
   36 root     root     bash
   66 root     root     ps
bash-4.3# sudo -u nginx -g nginx ls /var/lib/nginx/tmp/client_body/
bash-4.3# sudo -u nginx -g nginx ls /var/lib/nginx/tmp/client_body/
```

The issue itself appears to be initially triggered by a low-memory (or
even OOM) condition on the host. It persists until the `nginx` user can
(for some reason) again write to `client_body`, but it's unclear why
that eventually became the case in the shell session above.

I should mention that Nginx uses a set of very specific flags when
trying to open files in `client_body`, so it's possible that other
software would not be affected similarly (however, I do know that the
issue is *not* in Nginx: `strace` shows that the open failure does come
form the Kernel).

As a workaround, this patch allows the all-in-one registry to run with a
mounted `/var/lib/nginx` (mainly tests that prove it can), which might
allow circumventing the problem.

--

cc @fancyremarker @blakepettersson 