### PR TITLE
Support eu-west-2 by upgrading Distribution

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -11,6 +11,7 @@ RUN pip install supervisor==3.3.0
 ADD bin/install-registry-v1.sh /root/
 RUN /root/install-registry-v1.sh
 
+ENV PATH="/usr/local/go/bin:${PATH}"
 ADD bin/install-registry-v2.sh /root/
 RUN /root/install-registry-v2.sh
 

--- a/bin/install-registry-v2.sh
+++ b/bin/install-registry-v2.sh
@@ -22,7 +22,7 @@ mv go /usr/local/
 rm "$GO_FILENAME"
 
 GOPKG="github.com/docker/distribution"
-GIT_REF="5db89f0ca68677abc5eefce8f2a0a772c98ba52d"
+GIT_REF="bb49a1685d2773cb43dacc16e100419f310ba347"
 
 go get "$GOPKG"
 

--- a/bin/install-registry-v2.sh
+++ b/bin/install-registry-v2.sh
@@ -5,16 +5,29 @@ set -o nounset
 export GOPATH=/go
 
 apt-get update
-apt-get -y install golang librados2
+apt-get -y install librados2
 rm -rf /var/lib/apt/lists/*
 
+# Install Go (Xenial only provides Go 1.6.2, and the latest Distribution
+# requires Context, available only in Go 1.8+, so we install from Google)
+GO_VERSION=1.8.3
+GO_SHA256SUM=1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772
+GO_FILENAME="go${GO_VERSION}.linux-amd64.tar.gz"
+
+cd /tmp
+curl -O "https://storage.googleapis.com/golang/${GO_FILENAME}"
+echo "${GO_SHA256SUM} ${GO_FILENAME}" | sha256sum -c
+tar xzf "$GO_FILENAME"
+mv go /usr/local/
+rm "$GO_FILENAME"
+
 GOPKG="github.com/docker/distribution"
-GIT_TAG="v2.6.1"
+GIT_REF="5db89f0ca68677abc5eefce8f2a0a772c98ba52d"
 
 go get "$GOPKG"
 
 cd "/go/src/${GOPKG}"
-git checkout "$GIT_TAG"
+git checkout "$GIT_REF"
 make clean binaries
 
 mkdir -p /etc/docker/registry

--- a/test.sh
+++ b/test.sh
@@ -91,13 +91,13 @@ done
 
 # Now, we check that the prefixes addressed the right registries (and that the
 # default did so as well).
-docker logs "$APP_CONTAINER" | grep "PUT /v1/repositories/aptible/alpine-as-dualstack-v1"
-docker logs "$APP_CONTAINER" | grep 'http.request.uri="/v2/aptible/alpine-as-dualstack-v2/blobs/uploads/"'
+docker logs "$APP_CONTAINER" 2>&1 | grep "PUT /v1/repositories/aptible/alpine-as-dualstack-v1"
+docker logs "$APP_CONTAINER" 2>&1 | grep 'http.request.uri="/v2/aptible/alpine-as-dualstack-v2/blobs/uploads/"'
 
 if [[ "$TAG" = 1 ]]; then
-  docker logs "$APP_CONTAINER" | grep "PUT /v1/repositories/aptible/alpine-as-default"
+  docker logs "$APP_CONTAINER" 2>&1 | grep "PUT /v1/repositories/aptible/alpine-as-default"
 else
-  docker logs "$APP_CONTAINER" | grep 'http.request.uri="/v2/aptible/alpine-as-default/blobs/uploads/"'
+  docker logs "$APP_CONTAINER" 2>&1 | grep 'http.request.uri="/v2/aptible/alpine-as-default/blobs/uploads/"'
 fi
 
 echo "Done!"


### PR DESCRIPTION
Support for eu-west-2 was added in docker/distribution@9e510d6, which exists in no released tag of Distribution (only master). Additionally, the latest Distribution adds a dependency on context from Go 1.8. Since Xenial provides at best Go 1.6, we switch to installing Go from Google packages.

cc: @krallin 