### PR TITLE
Drop -e from docker login

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -73,7 +73,7 @@ for HOST_PREFIX in "" "dualstack-v1" "dualstack-v2"; do
   # to come up we don't care if it fails, since we'll know when we fail the push.
   echo "Logging in"
   for _ in $(seq 1 10); do
-    if docker login -e "foo@example.org" -u "$REGISTRY_USER" -p "$REGISTRY_PASS" "${REGISTRY_NAME}:${REGISTRY_PORT}"; then
+    if docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS" "${REGISTRY_NAME}:${REGISTRY_PORT}"; then
       break
     fi
     sleep 1


### PR DESCRIPTION
This flag has been removed so these tests will not pass on recent Docker
versions.

---

cc @fancyremarker 
fyi @UserNotFound : I'll rebase your https://github.com/aptible/docker-registry-all-in-one/pull/7 on top of master once I merge this (this is a fix for the specs that are failing there right now).